### PR TITLE
Add new payments events 

### DIFF
--- a/packages/js/types/index.d.ts
+++ b/packages/js/types/index.d.ts
@@ -11,12 +11,18 @@ export interface Checkout {
     event: "checkout.amounts_updated",
     callback: (data: { itemTotal: number; subtotalAmount: number; taxAmount: number; totalAmount: number }) => void,
   ): void;
+  on(event: "payment.started", callback: (data: PaymentStartedCallbackData) => void): void;
+  on(event: "payment.failed", callback: (data: PaymentFailedCallbackData) => void): void;
+  on(event: "payment.switch_country", callback: (data: SwitchCountryEventData) => void): void;
   off(event: "ready", callback: () => void): void;
   off(event: "purchase.completed", callback: (data: PurchaseCompletedCallbackData) => void): void;
   off(
     event: "checkout.amounts_updated",
     callback: (data: { itemTotal: number; subtotalAmount: number; taxAmount: number; totalAmount: number }) => void,
   ): void;
+  off(event: "payment.started", callback: (data: PaymentStartedCallbackData) => void): void;
+  off(event: "payment.failed", callback: (data: PaymentFailedCallbackData) => void): void;
+  off(event: "payment.switch_country", callback: (data: SwitchCountryEventData) => void): void;
   mount(domId: string): void;
   unmount(): void;
 }


### PR DESCRIPTION
We recently created three new payment events:
1. `payment.started`
2. `payment.failed`
3. `payment.switch_country`

We want to updates the types and publish here.