### PR TITLE
ENG-5112 | Update SwitchCountryCallBackData type with country code type

### DIFF
--- a/packages/js/types/index.d.ts
+++ b/packages/js/types/index.d.ts
@@ -21,6 +21,7 @@ export type SwitchCountryCallbackData = {
     id: string;
   };
   paymentMethodCountry: string | undefined;
+  paymentMethodCountryCode: string | undefined;
 };
 
 export interface Checkout {


### PR DESCRIPTION
Updating `SwitchCountryCallbackData` with new type `paymentMethodCountryCode` for recently-added new payment event: `payment.switch_country`